### PR TITLE
Re-apply fixed configuration with dmypy 1.5 for VSCode

### DIFF
--- a/.vscode/settings.default.json
+++ b/.vscode/settings.default.json
@@ -96,11 +96,10 @@
     "mypy-type-checker.importStrategy": "fromEnvironment",
     "mypy-type-checker.args": [
         "--custom-typeshed-dir=${workspaceFolder}",
-        "--python-version=3.7",
-        "--strict"
-        // Needed because a library stubbed in typeshed won't necessarily be installed inthe dev's environment
-        // Currentyl broken in dmypy: https://github.com/python/mypy/issues/10709
-        // "--ignore-missing-imports"
+        "--python-version=3.8",
+        "--strict",
+        // Needed because a library stubbed in typeshed won't necessarily be installed in the dev's environment
+        "--ignore-missing-imports"
     ],
     // Ensure typeshed's configs are used, and not user's VSCode settings
     "flake8.args": [


### PR DESCRIPTION
Figured since it's dependent on using mypy 1.5 . Which your PR is doing, may as well update this config together.