### PR TITLE
[stubsabot] Bump networkx to 3.3

### DIFF
--- a/stubs/networkx/METADATA.toml
+++ b/stubs/networkx/METADATA.toml
@@ -1,4 +1,4 @@
-version = "3.2.1"
+version = "3.3"
 upstream_repository = "https://github.com/networkx/networkx"
 requires = ["numpy"]
 partial_stub = true

--- a/tests/stubtest_third_party.py
+++ b/tests/stubtest_third_party.py
@@ -134,11 +134,11 @@ def run_stubtest(
             print_error("fail\n")
 
             print_divider()
-            print("Commands run:")
+            print("Commands run:", file=sys.stderr)
             print_commands(dist, pip_cmd, stubtest_cmd, mypypath)
 
             print_divider()
-            print("Command output:\n")
+            print("Command output:\n", file=sys.stderr)
             print_command_output(e)
 
             print_divider()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -61,7 +61,9 @@ def print_divider() -> None:
 
     This can be useful to divide terminal output into separate sections.
     """
+    print(file=sys.stderr)
     print("*" * 70, file=sys.stderr)
+    print(file=sys.stderr)
 
 
 # ====================================================================

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -41,19 +41,19 @@ def strip_comments(text: str) -> str:
 def print_command(cmd: str | Iterable[str]) -> None:
     if not isinstance(cmd, str):
         cmd = " ".join(cmd)
-    print(colored(f"Running: {cmd}", "blue"))
+    print(colored(f"Running: {cmd}", "blue"), file=sys.stderr)
 
 
 def print_error(error: str, end: str = "\n", fix_path: tuple[str, str] = ("", "")) -> None:
     error_split = error.split("\n")
     old, new = fix_path
     for line in error_split[:-1]:
-        print(colored(line.replace(old, new), "red"))
-    print(colored(error_split[-1], "red"), end=end)
+        print(colored(line.replace(old, new), "red"), file=sys.stderr)
+    print(colored(error_split[-1], "red"), end=end, file=sys.stderr)
 
 
 def print_success_msg() -> None:
-    print(colored("success", "green"))
+    print(colored("success", "green"), file=sys.stderr)
 
 
 def print_divider() -> None:
@@ -61,7 +61,7 @@ def print_divider() -> None:
 
     This can be useful to divide terminal output into separate sections.
     """
-    print("*" * 70)
+    print("*" * 70, file=sys.stderr)
 
 
 # ====================================================================


### PR DESCRIPTION
Release: https://pypi.org/pypi/networkx/3.3
Homepage: https://networkx.org/
Repository: https://github.com/networkx/networkx
Typeshed stubs: https://github.com/python/typeshed/tree/main/networkx

If stubtest fails for this PR:
- Leave this PR open (as a reminder, and to prevent stubsabot from opening another PR)
- Fix stubtest failures in another PR, then close this PR

Note that you will need to close and re-open the PR in order to trigger CI